### PR TITLE
editing filtered checklists function + clusters are back

### DIFF
--- a/develop/elsa_test.R
+++ b/develop/elsa_test.R
@@ -1,9 +1,0 @@
-## Search Box Elsa Test
-## 
-
-### When added to #setup block geojson layer adds an icon for a broad view centered around where you are located
-# addTiles() %>%
-#   addEasyButton(easyButton(
-#     icon="fa-crosshairs", title="Locate Me",
-#     onClick=JS("function(btn, map){ map.locate({setView: true}); }")))
-# })


### PR DESCRIPTION
 - displays species count per checklist
 - download checklists results in a list of checklists without a row for each species and checklist combo
 - this results in spiderfying markers working correctly, and also changed options so that the colored clustermarker is not over a clickable individual checklist dot. 