### PR TITLE
59 troubleshooting hours

### DIFF
--- a/20221209_noc_testing.r
+++ b/20221209_noc_testing.r
@@ -5,20 +5,19 @@ library(dplyr)
 if (!require(suncalc)) install.packages(
   "suncalc", repos = "http://cran.us.r-project.org")
 
-
 dt <- "2021-01-02"
 tm <- "10:11:00"
-
 
 dtfull <-paste(
     dt,
     tm,
     sep=" ")
 
-
 date=as.Date(dtfull, tz="EST")
 
-cData <- read.table("C:/Users/skanderson/OneDrive - State of North Carolina/@arcgis_projects/NCBA/20221209_noc_testing.csv", header=TRUE,sep=",")
+cData <- read.table(
+    paste0("C:/Users/skanderson/OneDrive - State of North Carolina/",
+    "@arcgis_projects/NCBA/20221209_noc_testing.csv"), header=TRUE,sep=",")
 
 cData$Date <- paste(
     cData$OBSERVATION_DATE,
@@ -61,10 +60,12 @@ st_labels <- c(
 
 test <- cut(as.Date(cData$Date),as.Date(savings_time_cutpoints),labels=st_labels)
 
-Species: 152
-Confirmed (C4): 35 
-Probable (C3): 20
-Possible (C2): 31
-Diurnal: 668 hrs
-Nocturnal: 2 hrs
-Total: 671 hrs
+
+# APEX-SE data
+# Species: 152
+# Confirmed (C4): 35 
+# Probable (C3): 20
+# Possible (C2): 31
+# Diurnal: 668 hrs
+# Nocturnal: 2 hrs
+# Total: 671 hrs

--- a/shinyapp/app.R
+++ b/shinyapp/app.R
@@ -313,7 +313,7 @@ server <- function(input, output, session) {
   # Applies filter WHEN CRITERIA CHANGES
   current_block_ebd_filtered <- reactive({
     req(current_block_ebd())
-
+    print(head(current_block_ebd()$EBD_NOCTURNAL))
     #make sure there are records to filter!
     validate(
       need(checklist_count()>0,"")
@@ -372,7 +372,7 @@ server <- function(input, output, session) {
         LOCALITY_TYPE,LONGITUDE,MONTH,NUMBER_OBSERVERS,OBSERVATION_DATE, # nolint
         OBSERVER_ID,PRIORITY_BLOCK,PROJECT_CODE,PROTOCOL_CODE,PROTOCOL_TYPE, # nolint
         SAMPLING_EVENT_IDENTIFIER,STATE,STATE_CODE,TIME_OBSERVATIONS_STARTED, # nolint
-        TRIP_COMMENTS,USFWS_CODE,YEAR) %>% # nolint
+        TRIP_COMMENTS,USFWS_CODE,YEAR,EBD_NOCTURNAL) %>% # nolint
       # ADD ADDITIONAL FILTERS HERE AS NEEDED
       # create a column with the html link https://ebird.org/checklist/SID
       mutate(

--- a/shinyapp/app.R
+++ b/shinyapp/app.R
@@ -513,10 +513,12 @@ server <- function(input, output, session) {
     #   num_spp_total, num_breed_confirm, num_breed_prob, num_breed_poss,
     #   num_breed_hours, sep='<br/>'))
     HTML(paste(
+      "<h4>Species</h4>",
       num_spp_total,
       num_breed_confirm,
       num_breed_prob,
       num_breed_poss,
+      "<h4>Hours</h4>",
       num_diurnal_hours,
       num_nocturnal_hours,
       num_total_hours,

--- a/shinyapp/utils.r
+++ b/shinyapp/utils.r
@@ -144,7 +144,7 @@ get_ebd_data <- function(query="{}", filter="{}", sd=safe_dates){
           '"PROJECT_CODE":1,"PROTOCOL_CODE":1,"PROTOCOL_TYPE":1,',
           '"SAMPLING_EVENT_IDENTIFIER":1,"STATE":1,"STATE_CODE":1,',
           '"TIME_OBSERVATIONS_STARTED":1,"TRIP_COMMENTS":1,',
-          '"USFWS_CODE":1,"YEAR":1}')
+          '"USFWS_CODE":1,"YEAR":1, "EBD_NOCTURNAL":1}')
 
         # fields excluded
         # "GEOM.coordinates":1,"GEOM.type":1,"NCBA_APPROVED":1,"NCBA_BLOCK":1,


### PR DESCRIPTION
Nocturnal hours not calculating correctly due to different timezone calculations locally and on server. Solved by modifying the EBD import process to calculate nocturnal status and add fields to each checklist document:

- EBD_NOCTURNAL: "1" or "0" depending if it satisfies the ebird rules for nocturnal (i.e., starts during "nocturnal" time)
- NCBA_NOCTURNAL: "1" or "0" depending on if any part of the checklist time is in the "nocturnal time (i.e., could start or end within nocturnal time)
- NCBA_NOCTURNAL_DURATION: XX in minutes - the amount of time of checklist during "nocturnal" time
- NCBA_OBSDT_UTC: DateTime object - the datetime of the checklist in UTC time - it is stored as a date (as opposed to other fields that are text.
- NCBA_NOCTURNAL_PARTIAL: "1" or "0" depending on if the checklist spans sunrise or sunset.

block_hrs function now uses the EBD_NOCTURNAL field to determine if the checklist is nocturnal.